### PR TITLE
added jstris to top next to tetrio and added firefox and chrome extension links for Jstris +

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The rentry releases of the Markdown file include centering arrows (-> <-) that a
 ## Administrators
 The administrators are the people with the current passcode to the Rentry page. Administrators ultimately update the Rentry page. 
 Current Admins: 
-1. Jed (Github: Degura) (Added 20230503) (Main Admin)
-2. Freyhoe (Github: freyhoe) (Added 20230504)
+1. Jed (Github: Degura) (Added 2023/05/03) (Main Admin)
+2. Freyhoe (Github: freyhoe) (Added 2023/05/04)
 
 ### Apply to become an Administrator
 People with a notable reputation in the community or with a streak of good contributions to the project can apply to become an administrator. Send your community member name (Discord, Github, other pertinent sites) and a brief (100 word max) explanation as to why you should be an administrator. 

--- a/tetriscommunity.md
+++ b/tetriscommunity.md
@@ -12,6 +12,7 @@ Calling this game "Tetris" and its consequences: https://blog.osk.sh/post.php?p=
 * PuyoTet World (PTW - Puyo Puyo Tetris Community) - https://discord.gg/puyopuyotetris
 * Tetris Effect: Connected Official Discord (Enhance) - https://discord.gg/enhance
 * TETR․IO Discord - https://discord.gg/tetrio
+* Jstris Discord - https://discord.gg/RcNFCZC
 
 ## 🥊 GET INVOLVED 🥊
 
@@ -52,7 +53,7 @@ Calling this game "Tetris" and its consequences: https://blog.osk.sh/post.php?p=
 
  * Jstris (Minimal client, uncapped speed/no delay, **free**): https://discord.gg/RcNFCZC
 
-    * Jstris Plus (extending Jstris with matchmaking, customization, better practice modes and a *lot more*!): https://greasyfork.org/en/scripts/451607-jstris
+    * Jstris Plus (extending Jstris with matchmaking, customization, better practice modes and a *lot more*!): [Greasy Fork](https://greasyfork.org/en/scripts/451607-jstris) [Chrome Extension](https://chrome.google.com/webstore/detail/jstris%2B/phbmcindealpgopeoboadcjlgcjdanmb) [FireFox Extension](https://addons.mozilla.org/en-US/firefox/addon/jstris/)
 
 *  Nuketris (Minimal client, speed limited, **free**): https://discord.gg/NUSgpfT5eH
 


### PR DESCRIPTION
It was odd that Tetrio was at the top and under the game sections so I thought it was fitting Jstris went alongside it. Add since some might find greasy fork a bit sketchy I added the Chrome web store and FireFox extension links under Jstris+.